### PR TITLE
修复传jsonStr类型导致部分华为机型收不到推送自定义参数的问题，将String类型换成Object，直接传JSON对象

### DIFF
--- a/src/main/java/com/tencent/xinge/bean/MessageAndroid.java
+++ b/src/main/java/com/tencent/xinge/bean/MessageAndroid.java
@@ -50,7 +50,7 @@ public class MessageAndroid {
     private ClickAction action;
 
     @JsonProperty(value = "custom_content")
-    private String custom_content;
+    private Object custom_content;
 
     public int getN_id() {
         return n_id;
@@ -148,11 +148,11 @@ public class MessageAndroid {
         this.action = action;
     }
 
-    public String getCustom_content() {
+    public Object getCustom_content() {
         return custom_content;
     }
 
-    public void setCustom_content(String custom_content) {
+    public void setCustom_content(Object custom_content) {
         this.custom_content = custom_content;
     }
 

--- a/src/main/java/com/tencent/xinge/bean/MessageIOS.java
+++ b/src/main/java/com/tencent/xinge/bean/MessageIOS.java
@@ -13,18 +13,18 @@ public class MessageIOS {
 
     @JsonProperty(value = "custom")
     @ApiModelProperty(notes = "自定义下发的参数")
-    private String custom;
+    private Object custom;
 
     @JsonProperty(value = "xg")
     @ApiModelProperty(notes = "系统保留key，应避免使用")
     private String xg;
 
 
-    public String  getCustom() {
+    public Object  getCustom() {
         return custom;
     }
 
-    public void setCustom(String custom) {
+    public void setCustom(Object custom) {
         this.custom = custom;
     }
 


### PR DESCRIPTION
发现的bug，望采纳